### PR TITLE
Support Nesting inside of TouchableOpacity

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
     }
 });
 
-const CACHED_IMAGE_REF = 'cachedImage' + (Math.floor(Math.random() * 1000000));
+const CACHED_IMAGE_REF = 'cachedImage';
 
 const CachedImage = React.createClass({
     propTypes: {

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -26,6 +26,8 @@ const styles = StyleSheet.create({
     }
 });
 
+const CACHED_IMAGE_REF = 'cachedImage' + (Math.floor(Math.random() * 1000000));
+
 const CachedImage = React.createClass({
     propTypes: {
         renderImage: React.PropTypes.func.isRequired,
@@ -38,14 +40,18 @@ const CachedImage = React.createClass({
 
     getDefaultProps() {
         return {
-            renderImage: props => (<Image ref={this.refName} {...props}/>),
+            renderImage: props => (<Image ref={CACHED_IMAGE_REF} {...props}/>),
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false
         };
     },
 
     setNativeProps(nativeProps) {
-        this.refs[this.refName].setNativeProps(nativeProps);
+        try {
+            this.refs[CACHED_IMAGE_REF].setNativeProps(nativeProps);
+        } catch (e) {
+            console.error(e);
+        }
     },
 
     getInitialState() {
@@ -65,8 +71,6 @@ const CachedImage = React.createClass({
     },
 
     componentWillMount() {
-        const rand = Math.floor(Math.random() * 1000000);
-        this.refName = 'cachedImage'+rand;
         this._isMounted = true;
         NetInfo.isConnected.addEventListener('change', this.handleConnectivityChange);
         // initial

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -38,10 +38,14 @@ const CachedImage = React.createClass({
 
     getDefaultProps() {
         return {
-            renderImage: props => (<Image {...props}/>),
+            renderImage: props => (<Image ref={this.refName} {...props}/>),
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false
         };
+    },
+
+    setNativeProps(nativeProps) {
+        this.refs[this.refName].setNativeProps(nativeProps);
     },
 
     getInitialState() {
@@ -61,6 +65,8 @@ const CachedImage = React.createClass({
     },
 
     componentWillMount() {
+        const rand = Math.floor(Math.random() * 1000000);
+        this.refName = 'cachedImage'+rand;
         this._isMounted = true;
         NetInfo.isConnected.addEventListener('change', this.handleConnectivityChange);
         // initial


### PR DESCRIPTION
Implemented setNativeProps() to support nesting `<CachedImage/>` component in `<TouchableOpacity/>`.

Currently, attempting to nest a `<CachedImage/>` as a child inside a `<TouchableOpacity/>` throws: 
>Invariant Violation: Touchable child must either be native or forward setNativeProps to a native component.

cc @wielrls 