### PR TITLE
Feature: Resolve headers

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -54,7 +54,7 @@ const CachedImage = React.createClass({
             renderImage: props => (<Image ref={CACHED_IMAGE_REF} {...props}/>),
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false,
-            resolveHeaders: Promise.resolve({})
+            resolveHeaders: () => Promise.resolve({})
         };
     },
 

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
 });
 
 function getImageProps(props) {
-    return _.omit(props, ['source', 'defaultSource', 'activityIndicatorProps', 'style', 'useQueryParamsInCacheKey', 'renderImage']);
+    return _.omit(props, ['source', 'defaultSource', 'activityIndicatorProps', 'style', 'useQueryParamsInCacheKey', 'renderImage', 'resolveHeaders']);
 }
 
 const CACHED_IMAGE_REF = 'cachedImage';
@@ -45,7 +45,8 @@ const CachedImage = React.createClass({
         useQueryParamsInCacheKey: React.PropTypes.oneOfType([
             React.PropTypes.bool,
             React.PropTypes.array
-        ]).isRequired
+        ]).isRequired,
+        resolveHeaders: React.PropTypes.func
     },
 
     getDefaultProps() {
@@ -118,7 +119,7 @@ const CachedImage = React.createClass({
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)
                 // try to put the image in cache if
-                .catch(() => ImageCacheProvider.cacheImage(url, options))
+                .catch(() => ImageCacheProvider.cacheImage(url, options, this.props.resolveHeaders))
                 .then(cachedImagePath => {
                     this.safeSetState({
                         cachedImagePath

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -53,7 +53,8 @@ const CachedImage = React.createClass({
         return {
             renderImage: props => (<Image ref={CACHED_IMAGE_REF} {...props}/>),
             activityIndicatorProps: {},
-            useQueryParamsInCacheKey: false
+            useQueryParamsInCacheKey: false,
+            resolveHeaders: Promise.resolve({})
         };
     },
 

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -121,13 +121,6 @@ function downloadImage(fromUrl, toFile, headers) {
     return activeDownloads[toFile];
 }
 
-function processResolveHeaders(resolveHeaders) {
-  if (_.isFunction(resolveHeaders)) {
-    return resolveHeaders();
-  }
-  return Promise.resolve({}); // return solved promise if no function given
-}
-
 function createPrefetcer(list) {
     const urls = _.clone(list);
     return {
@@ -186,7 +179,7 @@ function getCachedImagePath(url, options = defaultOptions) {
 function cacheImage(url, options = defaultOptions, resolveHeaders) {
     const filePath = getCachedImageFilePath(url, options);
     return ensurePath(filePath)
-        .then(() => processResolveHeaders(resolveHeaders))
+        .then(() => resolveHeaders())
         .then(headers => downloadImage(url, filePath, headers));
 }
 


### PR DESCRIPTION
In order to have images that requires authentication, we need to supply headers. 

With this addition one can provide a `resolveHeaders` function and have headers resolved before an image is downloaded.