### PR TITLE
Remove illegal characters from host name

### DIFF
--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -63,8 +63,9 @@ function getCachePath(url, options) {
     if (options.cacheGroup) {
         return options.cacheGroup;
     }
-    const parsedUrl = new URL(url);
-    return parsedUrl.host;
+    const { host } = new URL(url);
+    const sanitizedHost = host.replace(/[^a-z0-9]/gi, '').toLowerCase();
+    return sanitizedHost;
 }
 
 function getCachedImageFilePath(url, options) {


### PR DESCRIPTION
With this addition we avoid having illegal characters in the final file path for our image. Right now if there is a port number in your host (e.g. domain:1234) a directory called domain:1234 will be created, and colon in a path causes RNFetchBlob to crash on Android.