### PR TITLE
Allow changing the cache root directory

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -47,7 +47,7 @@ const CachedImage = React.createClass({
             React.PropTypes.array
         ]).isRequired,
         resolveHeaders: React.PropTypes.func,
-        cacheLocation: React.PropTypes.oneOf(Object.values(ImageCacheProvider.LOCATION)).isRequired
+        cacheLocation: React.PropTypes.string
     },
 
     getDefaultProps() {
@@ -118,8 +118,7 @@ const CachedImage = React.createClass({
     processSource(source) {
         const url = _.get(source, ['uri'], null);
         if (ImageCacheProvider.isCacheable(url)) {
-            let options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
-            options.cacheLocation = this.props.cacheLocation;
+            const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup', 'cacheLocation']);
 
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -46,7 +46,8 @@ const CachedImage = React.createClass({
             React.PropTypes.bool,
             React.PropTypes.array
         ]).isRequired,
-        resolveHeaders: React.PropTypes.func
+        resolveHeaders: React.PropTypes.func,
+        cacheLocation: React.PropTypes.oneOf(Object.values(ImageCacheProvider.LOCATION)).isRequired
     },
 
     getDefaultProps() {
@@ -54,7 +55,8 @@ const CachedImage = React.createClass({
             renderImage: props => (<Image ref={CACHED_IMAGE_REF} {...props}/>),
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false,
-            resolveHeaders: () => Promise.resolve({})
+            resolveHeaders: () => Promise.resolve({}),
+            cacheLocation: ImageCacheProvider.LOCATION.CACHE
         };
     },
 
@@ -116,7 +118,9 @@ const CachedImage = React.createClass({
     processSource(source) {
         const url = _.get(source, ['uri'], null);
         if (ImageCacheProvider.isCacheable(url)) {
-            const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
+            let options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
+            options.cacheLocation = this.props.cacheLocation;
+
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)
                 // try to put the image in cache if

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ When providing `source={{uri: 'https://example.com/path/to/remote/image.jpg'}}` 
 * `useQueryParamsInCacheKey` - _array|bool_ an array of keys to use from the `source.uri` query string or a bool value stating whether to use the entire query string or not. **(default: false)**
 * `defaultSource` - prop to display a background image while the source image is downloaded. This will work even in android, but will not display background image if there you set borderRadius on this component style prop
 * `resolveHeaders` - _function_ when provided, the returned object will be used as the headers object when sending the request to download the image. **(default: () => Promise.resolve({}))**
+* `cacheLocation` - _'cache'|'bundle'_ allows changing the root directory to use for caching. The default `'cache'` dir is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `'bundle'` if the cached images are critical (you will have to manage cleanup manually). **(default: 'cache')**
 
 ### ImageCacheProvider
 `ImageCacheProvider` exposes interaction with the cache layer that is used by `CachedImage` so you can use it to prefetch some urls in the background while you app is starting,
@@ -78,9 +79,10 @@ ImageCacheProvider.deleteMultipleCachedImages([
 
 #### `type: CacheOptions`
 ```
-type ReadDirItem = {
+type CacheOptions = {
   useQueryParamsInCacheKey: string[]|bool; // same as the CachedImage props
   cacheGroup: string; // the directory to save cached images in, defaults to the url hostname
+  cacheLocation: 'cache'|'bundle'; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to 'cache'
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ When providing `source={{uri: 'https://example.com/path/to/remote/image.jpg'}}` 
 * `useQueryParamsInCacheKey` - _array|bool_ an array of keys to use from the `source.uri` query string or a bool value stating whether to use the entire query string or not. **(default: false)**
 * `defaultSource` - prop to display a background image while the source image is downloaded. This will work even in android, but will not display background image if there you set borderRadius on this component style prop
 * `resolveHeaders` - _function_ when provided, the returned object will be used as the headers object when sending the request to download the image. **(default: () => Promise.resolve({}))**
-* `cacheLocation` - _'cache'|'bundle'_ allows changing the root directory to use for caching. The default `'cache'` dir is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `'bundle'` if the cached images are critical (you will have to manage cleanup manually). **(default: 'cache')**
+* `cacheLocation` - _string_ allows changing the root directory to use for caching. The default directory is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `ImageCacheProvider.LOCATION.BUNDLE` if the cached images are critical (you will have to manage cleanup manually). **(default: ImageCacheProvider.LOCATION.CACHE)**
 
 ### ImageCacheProvider
 `ImageCacheProvider` exposes interaction with the cache layer that is used by `CachedImage` so you can use it to prefetch some urls in the background while you app is starting,
@@ -82,7 +82,7 @@ ImageCacheProvider.deleteMultipleCachedImages([
 type CacheOptions = {
   useQueryParamsInCacheKey: string[]|bool; // same as the CachedImage props
   cacheGroup: string; // the directory to save cached images in, defaults to the url hostname
-  cacheLocation: 'cache'|'bundle'; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to 'cache'
+  cacheLocation: string; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to system cache directory
 };
 ```
 


### PR DESCRIPTION
This PR addresses what I already mentioned in #36:

### Background
Files in the default cache directory may be purged by the Android OS automatically to free up space. While this is fine in most cases, you may want to make sure that the cached images are permanent (when implementing an offline-mode for example). 

### API changes
This PR introduces a `cacheLocation` prop in CachedImage and a `cacheLocation` option in ImageCacheProvider. All utility functions like `clearCache` now take an optional parameter as well.

Possible values:

* `ImageCacheProvider.LOCATION.CACHE (='cache')` -> `fs.dirs.CacheDir`
* `ImageCacheProvider.LOCATION.BUNDLE (='bundle')` -> `fs.dirs.MainBundleDir`

Everything falls back to 'cache' so there should be no breaking changes.

### Feedback appreciated

I tested the `CachedImage` component and some of the caching functions in `ImageCacheProvider`. I did not get to test all of the utility functions like `collectFilesInfo`, `clearCache`, etc.
I verified that the images are stored in the respective directories.
I updated the README.
**I only tested on Android**

It'd be cool if your could look over the changes and test if you have the time.

Let me know what you think. I can fix stuff if needed.