### PR TITLE
Sometimes preview image will render instead of actual image

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -153,6 +153,7 @@ const CachedImage = React.createClass({
             } : this.props.source;
         return this.props.renderImage({
             ...props,
+            key: props.key || source.uri,
             style,
             source
         });
@@ -169,7 +170,7 @@ const CachedImage = React.createClass({
 
         // if the imageStyle has borderRadius it will break the loading image view on android
         // so we only show the ActivityIndicator
-        if (Platform.OS === 'android' && flattenStyle(imageStyle).borderRadius) {
+        if (!source || (Platform.OS === 'android' && flattenStyle(imageStyle).borderRadius)) {
             return (
                 <ActivityIndicator
                     {...activityIndicatorProps}
@@ -180,6 +181,7 @@ const CachedImage = React.createClass({
         return this.props.renderImage({
             ...imageProps,
             style: imageStyle,
+            key: source.uri,
             source,
             children: (
                 <ActivityIndicator


### PR DESCRIPTION
We're using a compressed version of an image to show a preview to the user while fetching the full image. After fetching the full size image, sometimes the app will still show the preview. This behaviour can be fixed by adding a key to the preview image.