### PR TITLE
Use activityIndicatorStyle in activityindicator instead of image style

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -174,7 +174,7 @@ const CachedImage = React.createClass({
             return (
                 <ActivityIndicator
                     {...activityIndicatorProps}
-                    style={[imageStyle, activityIndicatorStyle]}/>
+                    style={activityIndicatorStyle}/>
             );
         }
         // otherwise render an image with the defaultSource with the ActivityIndicator on top of it


### PR DESCRIPTION
Fixes invalid prop key warning issue when image style with `resizeMode` is passed to CachedImage
![image](https://user-images.githubusercontent.com/2553533/27072771-3723970a-502a-11e7-9c40-aced189d60e2.png)

Issue is also described in https://github.com/kfiroo/react-native-cached-image/issues/1