### PR TITLE
Limit number of parallel downloads

### DIFF
--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -205,7 +205,7 @@ function downloadImage(fromUrl, toFile, headers = {}) {
     return activeDownloads[toFile];
 }
 
-function createPrefetcer(list) {
+function createPrefetcher(list) {
     const urls = _.clone(list);
     return {
         next() {
@@ -327,12 +327,12 @@ function deleteCachedImage(url, options = defaultOptions) {
  * @returns {Promise}
  */
 function cacheMultipleImages(urls, options = defaultOptions) {
-    const prefetcher = createPrefetcer(urls);
     const numberOfWorkers = urls.length;
     const promises = _.times(numberOfWorkers, () =>
         runPrefetchTask(prefetcher, options)
     );
     return Promise.all(promises);
+    const prefetcher = createPrefetcher(urls);
 }
 
 /**

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -18,7 +18,10 @@ const defaultImageTypes = ['png', 'jpeg', 'jpg', 'gif', 'bmp', 'tiff', 'tif'];
 const defaultResolveHeaders = _.constant(defaultHeaders);
 
 const defaultOptions = {
-    useQueryParamsInCacheKey: false
+    useQueryParamsInCacheKey: false,
+    // Right now this options is used just by cacheMultipleImages
+    // 0 means no limit, a number different than that would be number of allowed concurrent tasks
+    numberOfParallelTasks: 0,
 };
 
 const activeDownloads = {};


### PR DESCRIPTION
We have the requirement of syncing a potential big number of images over a not so great internet connection.

In this scenario `ImageCacheProvider` will try to start all the downloads at the same time, which is fine for a relative small number of urls but can lead to errors, stale connections or even memory issues later on.

To get around that his PR propose a system that if the option `numberOfParallelTasks` is pass it will be used to adjust the number of concurrent downloads at any point in time, if the number is `0` it will fallback to the previous behaviour.

How to test:
- Use Charles or any similar Proxy to watch the connections or look at the cache directory to see how many files are being created (the later is less reliable)
- Before the patch
  - Create an array of several urls, 20 or so
  - Call `ImageCacheProvider` with the urls
  - See all calls starting at the same time
- After the patch
  - Create an array of several urls, 20 or so
  - Call `ImageCacheProvider` with the urls and `{numberOfParallelTasks: 5}`
  - See just 5 calls going on at the same time.
