### PR TITLE
Add read-only directory fallbacks

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -47,7 +47,7 @@ const CachedImage = React.createClass({
             React.PropTypes.array
         ]).isRequired,
         resolveHeaders: React.PropTypes.func,
-        cacheLocation: React.PropTypes.oneOf(Object.values(ImageCacheProvider.LOCATION)).isRequired
+        cacheLocation: React.PropTypes.string
     },
 
     getDefaultProps() {
@@ -118,8 +118,7 @@ const CachedImage = React.createClass({
     processSource(source) {
         const url = _.get(source, ['uri'], null);
         if (ImageCacheProvider.isCacheable(url)) {
-            let options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
-            options.cacheLocation = this.props.cacheLocation;
+            const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup', 'cacheLocation']);
 
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -47,7 +47,8 @@ const CachedImage = React.createClass({
             React.PropTypes.array
         ]).isRequired,
         resolveHeaders: React.PropTypes.func,
-        cacheLocation: React.PropTypes.string
+        cacheLocation: React.PropTypes.string,
+        readOnlyCacheDirs: React.PropTypes.arrayOf(React.PropTypes.string)
     },
 
     getDefaultProps() {
@@ -56,7 +57,8 @@ const CachedImage = React.createClass({
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false,
             resolveHeaders: () => Promise.resolve({}),
-            cacheLocation: ImageCacheProvider.LOCATION.CACHE
+            cacheLocation: ImageCacheProvider.LOCATION.CACHE,
+            readOnlyCacheDirs: null
         };
     },
 
@@ -118,7 +120,10 @@ const CachedImage = React.createClass({
     processSource(source) {
         const url = _.get(source, ['uri'], null);
         if (ImageCacheProvider.isCacheable(url)) {
-            const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup', 'cacheLocation']);
+            const options = _.pick(
+                this.props,
+                ['useQueryParamsInCacheKey', 'cacheGroup', 'cacheLocation', 'readOnlyCacheDirs']
+            );
 
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -156,9 +156,16 @@ const CachedImage = React.createClass({
         }
         const props = getImageProps(this.props);
         const style = this.props.style || styles.image;
-        const source = (this.state.isCacheable && this.state.cachedImagePath) ? {
-                uri: 'file://' + this.state.cachedImagePath
-            } : this.props.source;
+        let source = this.props.source;
+
+        if (this.state.isCacheable && this.state.cachedImagePath) {
+            if (this.state.cachedImagePath.substr(0, 16) === 'bundle-assets://') {
+                source = {uri: `${Platform.OS === 'android' ? 'asset:/' : ''}${this.state.cachedImagePath.substr(16)}`}
+            } else {
+                source = {uri: 'file://' + this.state.cachedImagePath};
+            }
+        }
+
         return this.props.renderImage({
             ...props,
             style,

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -46,7 +46,8 @@ const CachedImage = React.createClass({
             React.PropTypes.bool,
             React.PropTypes.array
         ]).isRequired,
-        resolveHeaders: React.PropTypes.func
+        resolveHeaders: React.PropTypes.func,
+        cacheLocation: React.PropTypes.oneOf(Object.values(ImageCacheProvider.LOCATION)).isRequired
     },
 
     getDefaultProps() {
@@ -54,7 +55,8 @@ const CachedImage = React.createClass({
             renderImage: props => (<Image ref={CACHED_IMAGE_REF} {...props}/>),
             activityIndicatorProps: {},
             useQueryParamsInCacheKey: false,
-            resolveHeaders: () => Promise.resolve({})
+            resolveHeaders: () => Promise.resolve({}),
+            cacheLocation: ImageCacheProvider.LOCATION.CACHE
         };
     },
 
@@ -116,7 +118,9 @@ const CachedImage = React.createClass({
     processSource(source) {
         const url = _.get(source, ['uri'], null);
         if (ImageCacheProvider.isCacheable(url)) {
-            const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
+            let options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
+            options.cacheLocation = this.props.cacheLocation;
+
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)
                 // try to put the image in cache if

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -80,15 +80,13 @@ function getCachePath(url, options) {
 function getCachedImageFilePaths(url, options) {
   const cachePath = getCachePath(url, options);
   const cacheKey = generateCacheKey(url, options);
-  let paths = [];
+  let paths = [`${getBaseDir(options.cacheLocation)}/${cachePath}/${cacheKey}`];
   if(options.readOnlyCacheDirs) {
-    paths = options.readOnlyCacheDirs.map(location => `${getBaseDir(location)}/${cachePath}/${cacheKey}`);
+    paths = paths.concat(options.readOnlyCacheDirs.map(location => `${getBaseDir(location)}/${cachePath}/${cacheKey}`));
   }
-  paths.push(`${getBaseDir(options.cacheLocation)}/${cachePath}/${cacheKey}`);
 
   return paths;
 }
-
 
 function getCachedImageFilePath(url, options) {
     const cachePath = getCachePath(url, options);
@@ -257,9 +255,9 @@ function getCachedImagePath(url, options = defaultOptions) {
     return Promise.all(promises)
         .then(resolutions => {
             const result = resolutions.reduce((accumulator, currentValue) => {
-            return accumulator instanceof String ? accumulator : currentValue;
+            return Object.prototype.toString.apply(accumulator) === '[object String]' ? accumulator : currentValue;
         }, new Error('Failed to get image from cache'));
-        if(result instanceof Error) {
+        if(Object.prototype.toString.apply(result) === '[object Error]') {
             throw result;
         }
         return result;

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -236,7 +236,7 @@ function getCachedImagePath(url, options = defaultOptions) {
     const filePaths = getCachedImageFilePaths(url, options);
     const promises = filePaths.map(filePath => fs.stat(filePath)
         .then(res => {
-            if (res.type !== 'file') {
+            if (['file', 'asset'].indexOf(res.type) === -1) {
                 // reject the promise if res is not a file
                 throw new Error('Failed to get image from cache');
             }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ When providing `source={{uri: 'https://example.com/path/to/remote/image.jpg'}}` 
 * `useQueryParamsInCacheKey` - _array|bool_ an array of keys to use from the `source.uri` query string or a bool value stating whether to use the entire query string or not. **(default: false)**
 * `defaultSource` - prop to display a background image while the source image is downloaded. This will work even in android, but will not display background image if there you set borderRadius on this component style prop
 * `resolveHeaders` - _function_ when provided, the returned object will be used as the headers object when sending the request to download the image. **(default: () => Promise.resolve({}))**
+* `cacheLocation` - _'cache'|'bundle'_ allows changing the root directory to use for caching. The default `'cache'` dir is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `'bundle'` if the cached images are critical (you will have to manage cleanup manually). **(default: 'cache')**
 
 ### ImageCacheProvider
 `ImageCacheProvider` exposes interaction with the cache layer that is used by `CachedImage` so you can use it to prefetch some urls in the background while you app is starting,
@@ -78,9 +79,10 @@ ImageCacheProvider.deleteMultipleCachedImages([
 
 #### `type: CacheOptions`
 ```
-type ReadDirItem = {
+type CacheOptions = {
   useQueryParamsInCacheKey: string[]|bool; // same as the CachedImage props
   cacheGroup: string; // the directory to save cached images in, defaults to the url hostname
+  cacheLocation: 'cache'|'bundle'; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to 'cache'
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ When providing `source={{uri: 'https://example.com/path/to/remote/image.jpg'}}` 
 * `useQueryParamsInCacheKey` - _array|bool_ an array of keys to use from the `source.uri` query string or a bool value stating whether to use the entire query string or not. **(default: false)**
 * `defaultSource` - prop to display a background image while the source image is downloaded. This will work even in android, but will not display background image if there you set borderRadius on this component style prop
 * `resolveHeaders` - _function_ when provided, the returned object will be used as the headers object when sending the request to download the image. **(default: () => Promise.resolve({}))**
-* `cacheLocation` - _'cache'|'bundle'_ allows changing the root directory to use for caching. The default `'cache'` dir is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `'bundle'` if the cached images are critical (you will have to manage cleanup manually). **(default: 'cache')**
+* `cacheLocation` - _string_ allows changing the root directory to use for caching. The default directory is sufficient for most use-cases. Images in this directory may be purged by Android automatically to free up space. Use `ImageCacheProvider.LOCATION.BUNDLE` if the cached images are critical (you will have to manage cleanup manually). **(default: ImageCacheProvider.LOCATION.CACHE)**
 
 ### ImageCacheProvider
 `ImageCacheProvider` exposes interaction with the cache layer that is used by `CachedImage` so you can use it to prefetch some urls in the background while you app is starting,
@@ -82,7 +82,7 @@ ImageCacheProvider.deleteMultipleCachedImages([
 type CacheOptions = {
   useQueryParamsInCacheKey: string[]|bool; // same as the CachedImage props
   cacheGroup: string; // the directory to save cached images in, defaults to the url hostname
-  cacheLocation: 'cache'|'bundle'; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to 'cache'
+  cacheLocation: string; // the root directory to use for caching, corresponds to CachedImage prop of same name, defaults to system cache directory
 };
 ```
 


### PR DESCRIPTION
Added ability to fallback on other read only directories for cached images. 

Includes #38.

The use-case for this involves shipping an app with pre-cached images in assets. Ideally we do not want to seedCache as this duplicates the files. This way we just show images straight from assets on both iOS and Android.

Testing this involves putting images assets on both platforms.

We have our options looking like this:
```
const imageCacheOptions = {
  useQueryParamsInCacheKey: false,
  cacheLocation: `${fs.dirs.DocumentDir}/imagesCacheDir`,
  readOnlyCacheDirs: [fs.asset('imagesCacheDir')],
};
```