### PR TITLE
Add proptypes from module prop types

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const React = require('react');
+const PropTypes = require('prop-types');
+const createReactClass = require('create-react-class');
 const ReactNative = require('react-native');
 const flattenStyle = ReactNative.StyleSheet.flatten;
 const ImageCacheProvider = require('./ImageCacheProvider');
@@ -39,7 +40,7 @@ function getImageProps(props) {
 
 const CACHED_IMAGE_REF = 'cachedImage';
 
-const CachedImage = React.createClass({
+const CachedImage = createReactClass({
     propTypes: {
         renderImage: React.PropTypes.func.isRequired,
         activityIndicatorProps: React.PropTypes.object.isRequired,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "crypto-js": "3.1.9-1",
     "lodash": "4.17.4",
     "react-native-fetch-blob": "0.10.4",
-    "url-parse": "1.1.7"
+    "url-parse": "1.1.7",
+    "prop-types": "^15.5.10",
+    "create-react-class": "^15.6.0"
   }
 }


### PR DESCRIPTION
This should fix #48 and also a similar issue with `React.createClass`. This change should not have any effect in the code apart of not triggering the warning about using deprecated code.