### PR TITLE
Updated react-native-fetch-blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "crypto-js": "3.1.9-1",
     "lodash": "4.17.4",
-    "react-native-fetch-blob": "0.10.4",
+    "react-native-fetch-blob": "0.10.7",
     "url-parse": "1.1.7"
   }
 }


### PR DESCRIPTION
start from react-native v0.47, createJSModule is removed in android and it causes android not building. In order to fix this issue, underline library `react-native-fetch-blob` needs to be upgraded.