### PR TITLE
URL cache host part hash

### DIFF
--- a/utils/pathUtils.js
+++ b/utils/pathUtils.js
@@ -45,7 +45,9 @@ function getHostCachePathComponent(url) {
     const {
         host
     } = new URL(url);
-    return host.replace(/[^a-z0-9]/gi, '').toLowerCase();
+
+    return host.replace(/\.:/gi, '_').replace(/[^a-z0-9_]/gi, '_').toLowerCase()
+      + '_' + SHA1(host);
 }
 
 /**


### PR DESCRIPTION
Resolves #95 

Will create cached file path like:
```${cacheLocation}/192_168_0_1_8000_hurirxv8nfp3mqail1ggsztxraimpjxpla18da86p56k916pd5/764df17y59r19mdug2eoi2e4esv1u02ygdwhiur1l965swfdr4.jpg```

Human readable host and resolves very rare file path conflicts.