### PR TITLE
Temporary fix for kfiroo/react-native-cached-image#125

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -52,7 +52,7 @@ class CachedImage extends React.Component {
     };
 
     static defaultProps = {
-            renderImage: props => (<ImageBackground imageStyle={props.style} ref={CACHED_IMAGE_REF} {...props} />),
+            renderImage: props => (<ImageBackground ref={CACHED_IMAGE_REF} {...props} />),
             activityIndicatorProps: {},
     };
 


### PR DESCRIPTION
NOTE: This worked for a few images but may not generalize to all cases.
If styles seem to be messed up later, it may be necessary to ask the
user to provide two sets of styles: (1) those that should be applied to
the outer ImageBackground component (e.g. positioning) and (2) those
that should be applied to the inner image component.