### PR TITLE
Use rn-fetch-blob over react-native-fetch-blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "4.17.4",
     "prop-types": "15.5.10",
     "react-native-clcasher": "1.0.0",
-    "react-native-fetch-blob": "0.10.8",
+    "rn-fetch-blob": "0.10.13",
     "url-parse": "1.1.9"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,13 +3510,6 @@ react-native-clcasher@1.0.0:
   dependencies:
     mock-async-storage "^1.0.3"
 
-react-native-fetch-blob@0.10.8:
-  version "0.10.8"
-  resolved "https://registry.yarnpkg.com/react-native-fetch-blob/-/react-native-fetch-blob-0.10.8.tgz#4fc256abae0cb5f10e7c41f28c11b3ff330d72a9"
-  dependencies:
-    base-64 "0.1.0"
-    glob "7.0.6"
-
 react-native@^0.48.3:
   version "0.48.3"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.3.tgz#ec17a66929eb292512b14c091cf260b25e2fba18"
@@ -3838,6 +3831,13 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
 rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
+rn-fetch-blob@0.10.8:
+  version "0.10.13"
+  resolved "https://registry.yarnpkg.com/rn-fetch-blob/-/rn-fetch-blob-0.10.13.tgz#e0fd5eac1a3a872563b35061353d96c4e51ae1cc"
+  dependencies:
+    base-64 "0.1.0"
+    glob "7.0.6"
 
 rndm@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
`react-native-fetch-blob` is no longer being maintained. From https://github.com/wkh237/react-native-fetch-blob:

> wkh237's last Github activity was in September 2017, and he has not reacted to emails either. This repository no longer is the main location of "react-native-fetch-blob".
> The owners of this fork have agreed to maintain this package:
> https://github.com/joltup/rn-fetch-blob

This PR aims to replace the unmaintained repo with a repo that is being maintained.