### PR TITLE
Use react-native-community/react-native-netinfo

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -16,10 +16,10 @@ const {
     View,
     ImageBackground,
     ActivityIndicator,
-    NetInfo,
     Platform,
     StyleSheet,
 } = ReactNative;
+const { NetInfo } = require("@react-native-community/netinfo");
 
 const styles = StyleSheet.create({
     image: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "react-native-cached-image",
+  "version": "1.4.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@react-native-community/netinfo": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.0.0.tgz",
+      "integrity": "sha512-jpeSQF4hb4fRI03uMmAwXyuObn+AdbL01zGQiUIcR9EDo+eu/q8tc4Z2kuxv2uTCfj+r/fptrElZDLd/ybMzuQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "typings": "./index.d.ts",
   "dependencies": {
+    "@react-native-community/netinfo": "^4.0.0",
     "crypto-js": "3.1.9-1",
     "lodash": "4.17.4",
     "prop-types": "15.5.10",


### PR DESCRIPTION
 NetInfo is completely removed from the code module of react-native -> https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#removed 
casing the component to fail to load 


![Screen Shot 2019-07-09 at 2 38 59 PM](https://user-images.githubusercontent.com/22164827/60925014-64e38e80-a257-11e9-9fd1-a98b17cf4f18.png)


PR is to import NetInfo from the community package -> https://github.com/react-native-community/react-native-netinfo