### PR TITLE
Bug/activity indicator for android

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
 });
 
 function getImageProps(props) {
-    return _.omit(props, ['source', 'defaultSource', 'fallbackSource', 'LoadingIndicator', 'activityIndicatorProps', 'style', 'useQueryParamsInCacheKey', 'renderImage', 'resolveHeaders']);
+    return _.omit(props, ['source', 'defaultSource', 'fallbackSource', 'loadingIndicator', 'activityIndicatorProps', 'style', 'useQueryParamsInCacheKey', 'renderImage', 'resolveHeaders']);
 }
 
 const CACHED_IMAGE_REF = 'cachedImage';
@@ -199,14 +199,14 @@ class CachedImage extends React.Component {
             if (LoadingIndicator) {
                 return (
                     <View style={[imageStyle, activityIndicatorStyle]}>
-                        <LoadingIndicator {...activityIndicatorProps} />
+                        <LoadingIndicator {...activityIndicatorProps} color="#063f71" />
                     </View>
                 );
             }
             return (
                 <ActivityIndicator
                     {...activityIndicatorProps}
-                    style={[imageStyle, activityIndicatorStyle]}/>
+                    style={[imageStyle, activityIndicatorStyle]} color="#063f71"/>
             );
         }
         // otherwise render an image with the defaultSource with the ActivityIndicator on top of it
@@ -218,11 +218,11 @@ class CachedImage extends React.Component {
             children: (
                 LoadingIndicator
                     ? <View style={[imageStyle, activityIndicatorStyle]}>
-                    <LoadingIndicator {...activityIndicatorProps} />
+                    <LoadingIndicator {...activityIndicatorProps} color="#063f71"/>
                 </View>
                     : <ActivityIndicator
                     {...activityIndicatorProps}
-                    style={activityIndicatorStyle}/>
+                    style={activityIndicatorStyle} color="#063f71"/>
             )
         });
     }

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -16,10 +16,11 @@ const {
     View,
     ImageBackground,
     ActivityIndicator,
-    NetInfo,
     Platform,
     StyleSheet,
 } = ReactNative;
+
+import NetInfo from "@react-native-community/netinfo";
 
 const styles = StyleSheet.create({
     image: {
@@ -79,9 +80,10 @@ class CachedImage extends React.Component {
 
     componentWillMount() {
         this._isMounted = true;
-        NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectivityChange);
+        NetInfo.addEventListener(this.handleConnectivityChange);
+        // NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectivityChange);
         // initial
-        NetInfo.isConnected.fetch()
+        NetInfo.fetch()
             .then(isConnected => {
                 this.safeSetState({
                     networkAvailable: isConnected
@@ -93,7 +95,8 @@ class CachedImage extends React.Component {
 
     componentWillUnmount() {
         this._isMounted = false;
-        NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectivityChange);
+        // NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectivityChange);
+        NetInfo.removeEventListener(this.handleConnectivityChange);
     }
 
     componentWillReceiveProps(nextProps) {

--- a/CachedImage.js
+++ b/CachedImage.js
@@ -81,7 +81,6 @@ class CachedImage extends React.Component {
     componentWillMount() {
         this._isMounted = true;
         NetInfo.addEventListener(this.handleConnectivityChange);
-        // NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectivityChange);
         // initial
         NetInfo.fetch()
             .then(isConnected => {
@@ -95,8 +94,6 @@ class CachedImage extends React.Component {
 
     componentWillUnmount() {
         this._isMounted = false;
-        // NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectivityChange);
-        NetInfo.removeEventListener(this.handleConnectivityChange);
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
The default color for ActivityIndicator on Android is a bug in the official library React native and should add a color property to fix it.

The bug is open, go to the link: https://github.com/facebook/react-native/pull/30057/files